### PR TITLE
Change SwiftSyntax upToNextMinor => upToNextMajor

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -38,7 +38,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .upToNextMinor(from: "0.50500.0")), // Minor releases correspond to Swift versions (i.e., use 0.50x000.y with Swift 5.x)
+        .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .upToNextMajor(from: "0.50500.0")), // Minor releases correspond to Swift versions (i.e., use 0.50x000.y with Swift 5.x)
         .package(name: "swift-argument-parser", url: "https://github.com/apple/swift-argument-parser.git", .upToNextMajor(from: "0.2.0")),
     ],
     targets: [


### PR DESCRIPTION
This will make it easier to keep up to date as new versions of Swift are
released (rather than having to manually make a pull request every
time).